### PR TITLE
Lauren/UI

### DIFF
--- a/findr_orchestrator/infrastructure/ui/get_oracle_node.sh
+++ b/findr_orchestrator/infrastructure/ui/get_oracle_node.sh
@@ -1,4 +1,4 @@
-#make sure jq is installed
+#install jq for mac
 brew install jq
 
 #get node port of oracle service
@@ -12,5 +12,5 @@ NODE_IP=$(kubectl get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type==
 #create oracle URL
 ORACLE_URL="http://${NODE_IP}:${NODE_PORT}"  
 
-#create json 
+#create json to set as external data in terraform
 jq -n --arg oracle_url "$ORACLE_URL" '{"oracle_url":$oracle_url}'

--- a/findr_orchestrator/infrastructure/ui/get_oracle_node.sh
+++ b/findr_orchestrator/infrastructure/ui/get_oracle_node.sh
@@ -1,0 +1,16 @@
+#make sure jq is installed
+brew install jq
+
+#get node port of oracle service
+NODE_PORT=$(kubectl get service -n oracle oracle-service -o=jsonpath='{.spec.ports[0].nodePort}')
+
+#get node ip of oracle pod
+POD_NAME=$(kubectl get pod -n oracle -l app=oracle -o jsonpath='{.items[0].metadata.name}')
+NODE_NAME=$(kubectl get pod $POD_NAME -n oracle -o jsonpath='{.spec.nodeName}')
+NODE_IP=$(kubectl get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+
+#create oracle URL
+ORACLE_URL="http://${NODE_IP}:${NODE_PORT}"  
+
+#create json 
+jq -n --arg oracle_url "$ORACLE_URL" '{"oracle_url":$oracle_url}'

--- a/findr_orchestrator/infrastructure/ui/get_oracle_node.sh
+++ b/findr_orchestrator/infrastructure/ui/get_oracle_node.sh
@@ -10,7 +10,7 @@ NODE_NAME=$(kubectl get pod $POD_NAME -n oracle -o jsonpath='{.spec.nodeName}')
 NODE_IP=$(kubectl get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
 
 #create oracle URL
-ORACLE_URL="http://${NODE_IP}:${NODE_PORT}"  
+ORACLE_URL="http://${NODE_IP}:${NODE_PORT}/oracle"  
 
 #create json to set as external data in terraform
 jq -n --arg oracle_url "$ORACLE_URL" '{"oracle_url":$oracle_url}'

--- a/findr_orchestrator/infrastructure/ui/main.tf
+++ b/findr_orchestrator/infrastructure/ui/main.tf
@@ -21,23 +21,11 @@ provider "kubernetes" {
   }
 }
 
-# Kubernetes ConfigMap
-resource "kubernetes_config_map" "env_config" {
-  metadata {
-    name      = "env-config"
-    namespace = var.namespace
-  }
-
-  data = {
-    FINDR_ORACLE_URL = var.findr_oracle_url
-  }
-}
-
 # Kubernetes Deployment
 resource "kubernetes_deployment" "ui_deployment" {
   metadata {
     name      = "ui"
-    namespace = var.namespace
+    namespace = var.ui_namespace
   }
 
   spec {
@@ -59,21 +47,7 @@ resource "kubernetes_deployment" "ui_deployment" {
       spec {
         container {
           name  = "ui-container"
-          image = var.ui_image
-
-          # Set the environment variables in the container
-          env {
-            name  = "FINDR_ORACLE_URL"
-            value = ""
-          }
-        }
-
-        # Mount the ConfigMap as a volume
-        volume {
-          name = "env-config-volume"
-          config_map {
-            name = kubernetes_config_map.env_config.metadata[0].name
-          }
+          image = "docker.io/pravnreddy429/findr_ui"  # Specify your Docker Hub image
         }
       }
     }
@@ -84,7 +58,7 @@ resource "kubernetes_deployment" "ui_deployment" {
 resource "kubernetes_service" "ui_service" {
   metadata {
     name      = "ui-service"
-    namespace = var.namespace
+    namespace = var.ui_namespace
   }
 
   spec {

--- a/findr_orchestrator/infrastructure/ui/main.tf
+++ b/findr_orchestrator/infrastructure/ui/main.tf
@@ -22,30 +22,19 @@ provider "kubernetes" {
 }
 
 #Get NodePort and NodeIP of Oracle for API endpoint
-resource "null_resource" "export_oracle" {
-  triggers = {
-    # Trigger when the service or any relevant configuration changes
-    service_version = kubernetes_service.oracle-service.metadata[0].resource_version
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-    #get nodeport
-      NODEPORT=\$(kubectl get service oracle-service -o=jsonpath='{.spec.ports[0].nodePort}')
-      export ORACLE_NODE_PORT
-    #get node
-      POD_NAME=$(kubectl get pod -n oracle -l app=oracle -o jsonpath='{.items[0].metadata.name}')
-      NODE_NAME=$(kubectl get pod $POD_NAME -n oracle -o jsonpath='{.spec.nodeName}')
-      NODE_IP=$(kubectl get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
-      export ORACLE_NODE_IP
-    EOT
-  }
+data "external" "oracle_info" {
+  program = ["bash", "${path.module}/get_oracle_node.sh"]
 }
 
+locals {
+  oracle_url = data.external.oracle_info.result.oracle_url
+}
 
 
 # Kubernetes Deployment
 resource "kubernetes_deployment" "ui_deployment" {
+  depends_on = [data.external.oracle_info]
+
   metadata {
     name      = "ui"
     namespace = var.ui_namespace
@@ -72,12 +61,8 @@ resource "kubernetes_deployment" "ui_deployment" {
           name  = "ui-container"
           image = "docker.io/pravnreddy429/findr_ui"  # Specify your Docker Hub image
           env {
-            name  = "REACT_APP_ORACLE_NODE_PORT"
-            value = "${null_resource.export_oracle.ORACLE_NODE_PORT}"
-          }
-          env {
-            name  = "REACT_APP_ORACLE_NODE_IP"
-            value = "${null_resource.export_oracle.ORACLE_NODE_IP}"
+            name  = "REACT_APP_ORACLE_URL"
+            value = "${local.oracle_url}"
           }
         }
       }

--- a/findr_orchestrator/infrastructure/ui/main.tf
+++ b/findr_orchestrator/infrastructure/ui/main.tf
@@ -21,6 +21,29 @@ provider "kubernetes" {
   }
 }
 
+#Get NodePort and NodeIP of Oracle for API endpoint
+resource "null_resource" "export_oracle" {
+  triggers = {
+    # Trigger when the service or any relevant configuration changes
+    service_version = kubernetes_service.oracle-service.metadata[0].resource_version
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+    #get nodeport
+      NODEPORT=\$(kubectl get service oracle-service -o=jsonpath='{.spec.ports[0].nodePort}')
+      export ORACLE_NODE_PORT
+    #get node
+      POD_NAME=$(kubectl get pod -n oracle -l app=oracle -o jsonpath='{.items[0].metadata.name}')
+      NODE_NAME=$(kubectl get pod $POD_NAME -n oracle -o jsonpath='{.spec.nodeName}')
+      NODE_IP=$(kubectl get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+      export ORACLE_NODE_IP
+    EOT
+  }
+}
+
+
+
 # Kubernetes Deployment
 resource "kubernetes_deployment" "ui_deployment" {
   metadata {
@@ -43,11 +66,19 @@ resource "kubernetes_deployment" "ui_deployment" {
           app = "ui"
         }
       }
-
+    
       spec {
         container {
           name  = "ui-container"
           image = "docker.io/pravnreddy429/findr_ui"  # Specify your Docker Hub image
+          env {
+            name  = "REACT_APP_ORACLE_NODE_PORT"
+            value = "${null_resource.export_oracle.ORACLE_NODE_PORT"
+          }
+          env {
+            name  = "REACT_APP_ORACLE_NODE_IP"
+            value = "${null_resource.export_oracle.ORACLE_NODE_IP}"
+          }
         }
       }
     }

--- a/findr_orchestrator/infrastructure/ui/main.tf
+++ b/findr_orchestrator/infrastructure/ui/main.tf
@@ -68,8 +68,8 @@ resource "kubernetes_service" "ui_service" {
 
     port {
       protocol   = "TCP"
-      port       = 7000
-      target_port = 7000
+      port       = 7001
+      target_port = 7001
     }
 
     type = "LoadBalancer"

--- a/findr_orchestrator/infrastructure/ui/main.tf
+++ b/findr_orchestrator/infrastructure/ui/main.tf
@@ -73,7 +73,7 @@ resource "kubernetes_deployment" "ui_deployment" {
           image = "docker.io/pravnreddy429/findr_ui"  # Specify your Docker Hub image
           env {
             name  = "REACT_APP_ORACLE_NODE_PORT"
-            value = "${null_resource.export_oracle.ORACLE_NODE_PORT"
+            value = "${null_resource.export_oracle.ORACLE_NODE_PORT}"
           }
           env {
             name  = "REACT_APP_ORACLE_NODE_IP"

--- a/findr_orchestrator/infrastructure/ui/outputs.tf
+++ b/findr_orchestrator/infrastructure/ui/outputs.tf
@@ -1,10 +1,13 @@
-output "pod_name" {
-  value       = kubernetes_deployment.ui_deployment.metadata[0].name
-  description = "The name of the deployed Kubernetes pod."
-  sensitive = true
+/** 
+Output for LoadBalancer IP
+This output provides instructions on how to retrieve the external IP address of the LoadBalancer.
+This external IP is used to access the ui and API.
+"Use 'kubectl get svc -n ui -o wide' to find the external IP address of ui's LoadBalancer service."
+
+
+output "ui_url" {
+  description = "Instruction to find the external IP address of ui's LoadBalancer"
+  value       = kubernetes_service.ui_service.load_balancer_ingress[0].hostname
 }
 
-output "load_balancer_ip" {
-  description = "Instruction to find the external IP address of Pod's LoadBalancer"
-  value       = "Use 'kubectl get svc -n var.namespace -o wide' to find the external IP address of Pod's LoadBalancer service."
-}
+**/

--- a/findr_orchestrator/infrastructure/ui/outputs.tf
+++ b/findr_orchestrator/infrastructure/ui/outputs.tf
@@ -1,13 +1,3 @@
-/** 
-Output for LoadBalancer IP
-This output provides instructions on how to retrieve the external IP address of the LoadBalancer.
-This external IP is used to access the ui and API.
-"Use 'kubectl get svc -n ui -o wide' to find the external IP address of ui's LoadBalancer service."
-
-
-output "ui_url" {
-  description = "Instruction to find the external IP address of ui's LoadBalancer"
-  value       = kubernetes_service.ui_service.load_balancer_ingress[0].hostname
+output "oracle_url" {
+  value = local.oracle_url
 }
-
-**/

--- a/findr_orchestrator/infrastructure/ui/variables.tf
+++ b/findr_orchestrator/infrastructure/ui/variables.tf
@@ -1,7 +1,7 @@
 /**
- * The Kubernetes namespace where oracle will be deployed
+ * The Kubernetes namespace where ui will be deployed
 */
-variable "namespace" {
+variable "ui_namespace" {
 
   /**
    * Description of Kubernetes namespace
@@ -14,14 +14,14 @@ variable "namespace" {
   type = string
 
   /**
-   * Default oracle namespace
-   */
+   * Default ui namespace
+   */ 
   default = "ui"
 
 }
 
 /**
- * The Kubernetes region where oracle will be deployed
+ * The Kubernetes region where ui will be deployed
 */
 variable "aws_region" {
 
@@ -37,20 +37,20 @@ variable "aws_region" {
 
   /**
    * Default aws region
-   */
+   */ 
   default = "us-east-1"
 
 }
 
 /**
- * The Kubernetes cluter name where oracle will be deployed
+ * The Kubernetes cluter name where ui will be deployed
 */
 variable "cluster_name" {
 
   /**
    * Description of what the cluster name is used for
    */
-  description = "The Kubernetes cluster where oracle is deployed"
+  description = "The Kubernetes cluster where ui is deployed"
 
   /**
    * Variable type
@@ -59,46 +59,7 @@ variable "cluster_name" {
 
   /**
    * Default cluster name
-   */
+   */ 
   default = "iot-findr"
-
-}
-
-/**
- * The findr orchestrator url
-*/
-variable "findr_oracle_url" {
-
-  /**
-   * Description of findr orchestrator url
-   */
-  description = "where Ui sends api request"
-
-  /**
-   * Variable type
-   */
-  type = string
-
-}
-
-/**
- * The oracle image url
-*/
-variable "ui_image" {
-
-  /**
-   * Description of oracle image url
-   */
-  description = "where UI docker image is"
-
-  /**
-   * Variable type
-   */
-  type = string
-
-  /**
-   * Default oracle image url
-   */
-  default = "docker.io/pravnreddy429/findr_ui:latest"
 
 }


### PR DESCRIPTION
-created script that terraform can execute. Because the output of the script is in json form, this data is accessible to terraform. So you set a parameter of that data (outputted json) equal to a local variable (locals) to set as an env var for the ui container. So, before the ui is deployed, a script is run by terraform to get the node ip and node port for oracle using kubectl commands. This outputted json is set to "external data" within terraform, then as a "local" variable which I then input to use as an environment variable for the UI pod. The UI uses process.env to access the oracle URL. 
Currently the URL is set as an output too but I can remove it. 